### PR TITLE
Add brush stroke toggle and tweak brush colors

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,6 +22,7 @@
   let showTrackA = $state(true);
   let showTrackB = $state(true);
   let showTrackC = $state(true);
+  let showBrushStroke = $state(true);
 </script>
 
 <h1>Drawing Tablet Lag Visualizer</h1>
@@ -32,6 +33,7 @@
     bind:showPointer bind:pointerStyle
     bind:showTrackA bind:showTrackB bind:showTrackC
     bind:showCircleA bind:showCircleB bind:showCircleC
+    bind:showBrushStroke
   />
   <Canvas
     {pointerLatency} {pointerSmoothing}
@@ -41,6 +43,7 @@
     {showPointer} {pointerStyle}
     {showCircleA} {showCircleB} {showCircleC}
     {showTrackA} {showTrackB} {showTrackC}
+    {showBrushStroke}
   />
 </div>
 

--- a/src/components/Canvas.svelte
+++ b/src/components/Canvas.svelte
@@ -28,6 +28,7 @@
     showTrackA,
     showTrackB,
     showTrackC,
+    showBrushStroke,
   } = $props();
 
   let canvasEl;
@@ -121,7 +122,7 @@
       }
 
       // Brush stroke trail
-      drawBrushStroke(ctx, brushTrail);
+      if (showBrushStroke) drawBrushStroke(ctx, brushTrail);
 
       // Draw elements back to front
       drawPosition(ctx, posC, 'c', showCircleC, showC);

--- a/src/components/SidePanel.svelte
+++ b/src/components/SidePanel.svelte
@@ -11,6 +11,7 @@
     showCircleA = $bindable(),
     showCircleB = $bindable(),
     showCircleC = $bindable(),
+    showBrushStroke = $bindable(),
   } = $props();
 </script>
 
@@ -40,6 +41,7 @@
     <label><input type="checkbox" bind:checked={showCircleA}> Circle a</label>
     <label><input type="checkbox" bind:checked={showCircleB}> Circle b</label>
     <label><input type="checkbox" bind:checked={showCircleC}> Circle c</label>
+    <label><input type="checkbox" bind:checked={showBrushStroke}> Brush stroke</label>
   </div>
 </div>
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -10,8 +10,8 @@ export const COLORS = {
   dashedLine: '#887860',
   penBody: ['#1480e0', '#1a6fc4', '#0e5090'],
   penTip: '#0e5090',
-  brushStroke: [150, 120, 90],
-  brushHighlight: [200, 170, 140],
+  brushStroke: [60, 140, 130],
+  brushHighlight: [110, 190, 180],
 };
 
 export const HISTORY_SIZE = 400;


### PR DESCRIPTION
Introduce a new showBrushStroke flag (App.svelte) and wire it through the UI and canvas: added bindable checkbox in SidePanel.svelte, passed the prop from App.svelte to Canvas.svelte, and made Canvas conditionally draw the brush trail only when enabled. Also adjust brush color constants in src/lib/constants.js to new RGB values for stroke and highlight to improve visual appearance.